### PR TITLE
remove use statements from ext_localconf.php

### DIFF
--- a/Classes/Authentication/FrontendUserGroupInjector.php
+++ b/Classes/Authentication/FrontendUserGroupInjector.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+namespace B13\Warmup\Authentication;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "warmup" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Magic logic to add user groups injected into $this->>info['alwaysActiveGroups']
+ */
+class FrontendUserGroupInjector extends AbstractAuthenticationService
+{
+    /**
+     * @param $user
+     * @param $knownGroups
+     * @return array
+     */
+    public function getGroups($user, $knownGroups)
+    {
+        $groupIds = $this->info['alwaysActiveGroups'] ?? [];
+        if (!empty($groupIds)) {
+            // Also request a user
+            // @todo: should fetch the whole record, probably in a separate hook
+            if ($this->info['requestUser'] ?? false) {
+                $this->pObj->user['uid'] = (int)$this->info['requestUser'];
+            }
+            return $this->fetchGroupsFromDatabase($groupIds);
+        }
+        $this->logger->warning(self::class . ' was activated, but no user groups were set');
+        return [];
+    }
+
+    private function fetchGroupsFromDatabase(array $groupUids): array
+    {
+        $groupRecords = [];
+        $this->logger->debug('Get usergroups with id: ' . implode(',', $groupUids));
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('fe_groups');
+
+        $res = $queryBuilder->select('*')
+            ->from('fe_groups')
+            ->where(
+                $queryBuilder->expr()->in(
+                    'uid',
+                    $queryBuilder->createNamedParameter($groupUids, Connection::PARAM_INT_ARRAY)
+                )
+            )
+            ->execute();
+
+        while ($row = $res->fetch()) {
+            $groupRecords[$row['uid']] = $row;
+        }
+        return $groupRecords;
+    }
+}

--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -1,26 +1,22 @@
 <?php
 declare(strict_types = 1);
-namespace CMSExperts\Warmup\Command;
+namespace B13\Warmup\Command;
 
 /*
- * This file is part of the TYPO3 Warmup Extension.
+ * This file is part of TYPO3 CMS-based extension "warmup" by b13.
  *
  * It is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License, either version 2
  * of the License, or any later version.
- *
- * For the full copyright and license information, please read the
- * LICENSE.txt file that was distributed with this source code.
  */
+
+use B13\Warmup\Service\PageWarmupService;
+use B13\Warmup\Service\RootlineV8Service;
+use B13\Warmup\Service\RootlineWarmupService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\RootlineUtility;
-use TYPO3\CMS\Frontend\Page\PageRepository;
 
 /**
  * Called via cache:warmup
@@ -43,102 +39,30 @@ class WarmupCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Welcome to the Cache Warmup');
 
-        $io->writeln('Warming up the rootline for all pages. If it is there this will go fast.');
-        $errors = $this->warmupRootline($io);
+        if (version_compare(TYPO3_branch, '9.5') === -1) {
+            $io->writeln('Warming up the rootline for all pages. If it is there this will go fast.');
+            $rootlineService = new RootlineV8Service();
+            $errors = $rootlineService->warmUp($io);
+        } else {
+#            $io->writeln('Warming up the rootline for all pages. If it is there this will go fast.');
+#            $rootlineService = new RootlineWarmupService();
+#            $errors = $rootlineService->warmUp($io);
+            $io->writeln('Calling all pages.');
+            $pageService = new PageWarmupService();
+            $pageService->warmUp($io);
+        }
         if (!empty($errors)) {
             $io->error('Error while warming up the rootline cache.');
             $io->listing($errors);
             return 1;
         }
-        $io->writeln('All done');
+        $io->success('All done');
         return 0;
     }
 
-    /**
-     * Runs through all pages and pages_language_overlay records
-     * and builds the rootline for each page.
-     *
-     * The Rootline Utility does the rest by storing this data to the cache_rootline cache
-     * if it has not happened yet.
-     *
-     * @param SymfonyStyle $io
-     * @return array the page Ids with errors
-     */
-    protected function warmupRootline(SymfonyStyle $io): array
+    private function getWarmupService(string $type): iterable
     {
-        $erroredPageIds = [];
-        $pageRepository = $this->initializePageRepository();
-
-        // fetch all pages which are not deleted and in live workspace
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('pages');
-        $queryBuilder->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        $statement = $queryBuilder->select('uid')->from('pages')->execute();
-        while ($pageRecord = $statement->fetch()) {
-            try {
-                $this->buildRootLineForPage(
-                    (int)$pageRecord['uid'],
-                    0,
-                    $pageRepository
-                );
-            } catch (\RuntimeException $e) {
-                $erroredPageIds[] = 'Page ID: ' . $pageRecord['uid'];
-            }
-        }
-
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('pages_language_overlay');
-        $queryBuilder->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        $statement = $queryBuilder->select('pid', 'sys_language_uid')->from('pages_language_overlay')->execute();
-        while ($pageTranslationRecord = $statement->fetch()) {
-            try {
-                $this->buildRootLineForPage(
-                    (int)$pageTranslationRecord['pid'],
-                    (int)$pageTranslationRecord['sys_language_uid'],
-                    $pageRepository
-                );
-            } catch (\RuntimeException $e) {
-                $erroredPageIds[] = 'Page ID: ' . $pageTranslationRecord['pid'] . ' (Language: ' . $pageTranslationRecord['sys_language_uid'] . ')';
-            }
-        }
-
-        return $erroredPageIds;
-    }
-
-    /**
-     * Calls the Rootline Utility and build the rootline for a specific page in a specific language
-     *
-     * @param int $pageUid
-     * @param int $languageUid
-     * @param PageRepository $pageRepository
-     */
-    protected function buildRootLineForPage(int $pageUid, int $languageUid, PageRepository $pageRepository)
-    {
-        $pageRepository->sys_language_uid = $languageUid;
-        GeneralUtility::makeInstance(RootlineUtility::class, $pageUid, '', $pageRepository)->get();
-    }
-
-    /**
-     * Sets up the PageRepository object with default language and no workspace functionality
-     *
-     * @return PageRepository
-     */
-    protected function initializePageRepository(): PageRepository
-    {
-        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
-        $pageRepository->versioningPreview = false;
-        $pageRepository->sys_language_uid = 0;
-        $pageRepository->versioningWorkspaceId = 0;
-        $pageRepository->init(false);
-
-        // Due to some ugly code in TYPO3 Core, we must fake a TSFE object
-        $GLOBALS['TSFE'] = new \stdClass();
-        $GLOBALS['TSFE']->sys_page = $pageRepository;
-        $GLOBALS['TSFE']->gr_list = '0,-1';
-        return $pageRepository;
+        if (version_compare(TYPO3_branch, '9.5') === -1) {
+            new RootlineV8Service();
     }
 }

--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -14,6 +14,7 @@ use B13\Warmup\Service\PageWarmupService;
 use B13\Warmup\Service\RootlineV8Service;
 use B13\Warmup\Service\RootlineWarmupService;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -23,12 +24,21 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 class WarmupCommand extends Command
 {
+    private $io;
+
     /**
      * Configure the command by defining the name, options and arguments
      */
     public function configure()
     {
-        $this->setDescription('Warms up some basic caches for frontend rendering.');
+        $this
+            ->setDescription('Warms up some basic caches for frontend rendering.')
+            ->addArgument(
+                'type',
+                InputArgument::OPTIONAL,
+                'Choose between "rootline" and "pages", or "all"',
+                'all'
+            );
     }
 
     /**
@@ -36,33 +46,38 @@ class WarmupCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $io = new SymfonyStyle($input, $output);
-        $io->title('Welcome to the Cache Warmup');
+        $this->io = new SymfonyStyle($input, $output);
+        $this->io->title('Welcome to the Cache Warmup');
 
-        if (version_compare(TYPO3_branch, '9.5') === -1) {
-            $io->writeln('Warming up the rootline for all pages. If it is there this will go fast.');
-            $rootlineService = new RootlineV8Service();
-            $errors = $rootlineService->warmUp($io);
-        } else {
-#            $io->writeln('Warming up the rootline for all pages. If it is there this will go fast.');
-#            $rootlineService = new RootlineWarmupService();
-#            $errors = $rootlineService->warmUp($io);
-            $io->writeln('Calling all pages.');
-            $pageService = new PageWarmupService();
-            $pageService->warmUp($io);
+        $type = $input->getArgument('type');
+
+        foreach ($this->getWarmupService($type) as $specificType => $service) {
+            $this->io->section('Warming up ' . $specificType);
+            call_user_func_array([$service, 'warmUp'], [$this->io]);
         }
-        if (!empty($errors)) {
-            $io->error('Error while warming up the rootline cache.');
-            $io->listing($errors);
-            return 1;
-        }
-        $io->success('All done');
+
+        $this->io->success('All done');
         return 0;
     }
 
     private function getWarmupService(string $type): iterable
     {
         if (version_compare(TYPO3_branch, '9.5') === -1) {
-            new RootlineV8Service();
+            yield 'rootline' => new RootlineV8Service();
+        } else {
+            switch ($type) {
+                case 'all':
+                    yield 'rootline' => new RootlineWarmupService();
+                    yield 'pages' => new PageWarmupService();
+                    break;
+                case 'rootline':
+                    yield 'rootline' => new RootlineWarmupService();
+                    break;
+                case 'pages':
+                    yield 'pages' => new RootlineWarmupService();
+                    break;
+
+            }
+        }
     }
 }

--- a/Classes/Command/WarmupCommand.php
+++ b/Classes/Command/WarmupCommand.php
@@ -74,7 +74,7 @@ class WarmupCommand extends Command
                     yield 'rootline' => new RootlineWarmupService();
                     break;
                 case 'pages':
-                    yield 'pages' => new RootlineWarmupService();
+                    yield 'pages' => new PageWarmupService();
                     break;
 
             }

--- a/Classes/FrontendRequestBuilder.php
+++ b/Classes/FrontendRequestBuilder.php
@@ -1,0 +1,202 @@
+<?php
+declare(strict_types=1);
+
+namespace B13\Warmup;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "warmup" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Core\ApplicationContext;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Error\Http\PageNotFoundException;
+use TYPO3\CMS\Core\Http\ImmediateResponseException;
+use TYPO3\CMS\Core\Http\MiddlewareDispatcher;
+use TYPO3\CMS\Core\Http\MiddlewareStackResolver;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Package\PackageManager;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Exception\RequiredArgumentMissingException;
+use TYPO3\CMS\Extbase\Service\EnvironmentService;
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
+use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
+use TYPO3\CMS\Frontend\Http\RequestHandler;
+
+class FrontendRequestBuilder
+{
+    private $originalUser;
+
+    private $backedUpEnvironment = [];
+
+    private $originalEnvironmentService;
+
+    private function prepare()
+    {
+        $this->originalUser = $GLOBALS['BE_USER'];
+        $this->backupEnvironment();
+        $this->initializeEnvironmentForNonCliCall(GeneralUtility::getApplicationContext());
+
+        $this->originalEnvironmentService = GeneralUtility::makeInstance(EnvironmentService::class);
+        $environmentService = new class extends EnvironmentService {
+            public function isEnvironmentInFrontendMode()
+            {
+                return true;
+            }
+            public function isEnvironmentInBackendMode()
+            {
+                return false;
+            }
+            public function isEnvironmentInCliMode()
+            {
+                return false;
+            }
+        };
+        GeneralUtility::setSingletonInstance(EnvironmentService::class, $environmentService);
+        GeneralUtility::setSingletonInstance(Dispatcher::class, new Dispatcher());
+
+        $GLOBALS['BE_USER'] = null;
+        unset($GLOBALS['TSFE']);
+    }
+
+    private function restore()
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['postUserLookUp']['frontendrequestbuilder'];
+        $GLOBALS['BE_USER'] = $this->originalUser;
+        GeneralUtility::setSingletonInstance(EnvironmentService::class, $this->originalEnvironmentService);
+        unset($GLOBALS['TSFE']);
+        $this->restoreEnvironment();
+    }
+
+
+    public function buildRequestForPage(UriInterface $uri, $frontendUserGroups = []): ?ResponseInterface
+    {
+        $this->prepare();
+        $request = new ServerRequest($uri, 'GET');
+
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_userauth.php']['postUserLookUp']['frontendrequestbuilder'] = function($parameters, $parentObject) use ($frontendUserGroups) {
+            if (!empty($frontendUserGroups) && $parentObject instanceof FrontendUserAuthentication) {
+                $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+                    ->getQueryBuilderForTable('fe_users');
+                $parentObject->user = $queryBuilder
+                    ->select('*')
+                    ->from('fe_users')
+                    ->where(
+                        $queryBuilder->expr()->eq('usergroup', $queryBuilder->createNamedParameter(implode(',', $frontendUserGroups)))
+                    )
+                    ->setMaxResults(1)
+                    ->execute()
+                    ->fetch();
+            }
+        };
+
+        $response = null;
+        try {
+            $response = $this->executeFrontendRequest($request);
+            #var_dump($response->getBody()->getContents());
+        } catch (ImmediateResponseException $e) {
+            $response = $e->getResponse();
+            #var_dump($response->getBody()->getContents());
+            var_dump($response->getReasonPhrase());
+        } catch (RequiredArgumentMissingException $e) {
+            // @todo: log
+        } catch (PageNotFoundException $e) {
+            // @todo: log
+        } catch (\Throwable $e) {
+            var_dump(get_class($e));
+        }
+
+        $this->restore();
+
+        return $response;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function executeFrontendRequest(ServerRequestInterface $request): ResponseInterface
+    {
+        $dispatcher = $this->buildDispatcher();
+        return $dispatcher->handle($request);
+    }
+
+    /**
+     * @return MiddlewareDispatcher
+     * @throws \TYPO3\CMS\Core\Cache\Exception\InvalidDataException
+     * @throws \TYPO3\CMS\Core\Cache\Exception\NoSuchCacheException
+     * @throws \TYPO3\CMS\Core\Exception
+     */
+    private function buildDispatcher()
+    {
+        $requestHandler = GeneralUtility::makeInstance(RequestHandler::class);
+        $resolver = new MiddlewareStackResolver(
+            GeneralUtility::makeInstance(PackageManager::class),
+            GeneralUtility::makeInstance(DependencyOrderingService::class),
+            GeneralUtility::makeInstance(CacheManager::class)->getCache('cache_core')
+        );
+        $middlewares = $resolver->resolve('frontend');
+        return new MiddlewareDispatcher($requestHandler, $middlewares);
+    }
+
+    private function initializeEnvironmentForNonCliCall(ApplicationContext $applicationContext): void
+    {
+        Environment::initialize(
+            $applicationContext,
+            false,
+            Environment::isComposerMode(),
+            Environment::getProjectPath(),
+            Environment::getPublicPath(),
+            Environment::getVarPath(),
+            Environment::getConfigPath(),
+            Environment::getCurrentScript(),
+            Environment::isWindows() ? 'WINDOWS' : 'UNIX'
+        );
+    }
+
+    /**
+     * Helper method used in setUp() if $this->backupEnvironment is true
+     * to back up current state of the Environment::class
+     */
+    private function backupEnvironment(): void
+    {
+        $this->backedUpEnvironment['context'] = Environment::getContext();
+        $this->backedUpEnvironment['isCli'] = Environment::isCli();
+        $this->backedUpEnvironment['composerMode'] = Environment::isComposerMode();
+        $this->backedUpEnvironment['projectPath'] = Environment::getProjectPath();
+        $this->backedUpEnvironment['publicPath'] = Environment::getPublicPath();
+        $this->backedUpEnvironment['varPath'] = Environment::getVarPath();
+        $this->backedUpEnvironment['configPath'] = Environment::getConfigPath();
+        $this->backedUpEnvironment['currentScript'] = Environment::getCurrentScript();
+        $this->backedUpEnvironment['isOsWindows'] = Environment::isWindows();
+    }
+
+    /**
+     * Helper method used in tearDown() if $this->backupEnvironment is true
+     * to reset state of Environment::class
+     */
+    private function restoreEnvironment(): void
+    {
+        Environment::initialize(
+            $this->backedUpEnvironment['context'],
+            $this->backedUpEnvironment['isCli'],
+            $this->backedUpEnvironment['composerMode'],
+            $this->backedUpEnvironment['projectPath'],
+            $this->backedUpEnvironment['publicPath'],
+            $this->backedUpEnvironment['varPath'],
+            $this->backedUpEnvironment['configPath'],
+            $this->backedUpEnvironment['currentScript'],
+            $this->backedUpEnvironment['isOsWindows'] ? 'WINDOWS' : 'UNIX'
+        );
+    }
+}

--- a/Classes/Service/PageWarmupService.php
+++ b/Classes/Service/PageWarmupService.php
@@ -53,7 +53,7 @@ class PageWarmupService
             ->add(GeneralUtility::makeInstance(HiddenRestriction::class))
             ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
         $statement = $queryBuilder->select('*')->from('pages')->where(
-            $queryBuilder->expr()->lt('doktype', 199),
+            $queryBuilder->expr()->eq('doktype', 1), //call only standard pages
             $queryBuilder->expr()->eq('sys_language_uid', 0)
         )->execute();
 

--- a/Classes/Service/PageWarmupService.php
+++ b/Classes/Service/PageWarmupService.php
@@ -57,7 +57,7 @@ class PageWarmupService
             $queryBuilder->expr()->eq('sys_language_uid', 0)
         )->execute();
 
-        $io->writeln('Starting to request pages at ' . strftime('d.m.Y H:i:s'));
+        $io->writeln('Starting to request pages at ' . date('d.m.Y H:i:s'));
         $requestedPages = 0;
 
         while ($pageRecord = $statement->fetch()) {
@@ -77,7 +77,7 @@ class PageWarmupService
             }
         }
 
-        $io->writeln('Finished requesting ' . $requestedPages . ' pages at ' . strftime('d.m.Y H:i:s'));
+        $io->writeln('Finished requesting ' . $requestedPages . ' pages at ' . date('d.m.Y H:i:s'));
     }
 
     /**

--- a/Classes/Service/PageWarmupService.php
+++ b/Classes/Service/PageWarmupService.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+namespace B13\Warmup\Service;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "warmup" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Warmup\FrontendRequestBuilder;
+use Psr\Http\Message\UriInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+
+class PageWarmupService
+{
+    private $io;
+
+    /**
+     * @todo: implement this via constructor
+     * @var array
+     */
+    private $excludePages = [];
+
+    public function warmUp(SymfonyStyle $io): array
+    {
+        $this->io = $io;
+        $erroredPageIds = [];
+        // fetch all pages which are not deleted and in live workspace
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('pages');
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class))
+            ->add(GeneralUtility::makeInstance(HiddenRestriction::class))
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $statement = $queryBuilder->select('*')->from('pages')->where(
+            $queryBuilder->expr()->lt('doktype', 199),
+            $queryBuilder->expr()->lte('sys_language_uid', 0)
+        )->execute();
+
+        $io->writeln('Starting to request pages at ' . strftime('d.m.Y H:i:s'));
+        $requestedPages = 0;
+
+        while ($pageRecord = $statement->fetch()) {
+            if (in_array((int)$pageRecord['uid'], $this->excludePages, true)) {
+                continue;
+            }
+            try {
+                $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId((int)$pageRecord['uid']);
+                $languageUid = (int)$pageRecord['sys_language_uid'];
+                $siteLanguage = $site->getLanguageById($languageUid);
+                $url = $site->getRouter()->generateUri($pageRecord, ['_language' => $siteLanguage]);
+                $this->executeRequestForPageRecord($url, $pageRecord);
+                $requestedPages++;
+
+            } catch (SiteNotFoundException $e) {
+                $erroredPageIds[] = 'Page ID: ' . $pageRecord['uid'];
+            }
+        }
+
+        $io->writeln('Finished requesting ' . $requestedPages . ' pages at ' . strftime('d.m.Y H:i:s'));
+
+        return $erroredPageIds;
+    }
+
+    /**
+     * @param UriInterface $url
+     * @param array $pageRecord
+     */
+    protected function executeRequestForPageRecord(UriInterface $url, array $pageRecord)
+    {
+        Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class);
+        Bootstrap::initializeBackendAuthentication();
+        Bootstrap::initializeBackendRouter();
+
+        $userGroups = $this->resolveRequestedUserGroupsForPage($pageRecord);
+
+        $this->io->writeln('Calling ' . (string)$url . ' (Page ID: ' . $pageRecord['uid'] . ', UserGroups: ' . implode(',', $userGroups) . ')');
+
+        $builder = new FrontendRequestBuilder();
+        $builder->buildRequestForPage($url, $userGroups);
+    }
+
+    protected function resolveRequestedUserGroupsForPage(array $pageRecord)
+    {
+        $userGroups = $pageRecord['fe_group'];
+        $rootLine = GeneralUtility::makeInstance(RootlineUtility::class, $pageRecord['uid'])->get();
+        foreach ($rootLine as $pageInRootLine) {
+            if ($pageInRootLine['extendToSubpages']) {
+                $userGroups .= ',' . $pageInRootLine['fe_group'];
+            }
+        }
+        $userGroups = GeneralUtility::intExplode(',', $userGroups, true);
+        $userGroups = array_filter($userGroups);
+        $userGroups = array_unique($userGroups);
+        return $userGroups;
+    }
+}

--- a/Classes/Service/RootlineV8Service.php
+++ b/Classes/Service/RootlineV8Service.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+namespace B13\Warmup\Service;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "warmup" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+use TYPO3\CMS\Frontend\Page\PageRepository;
+
+/**
+ * Warms up the root line for v8.
+ */
+class RootlineV8Service
+{
+    /**
+     * Runs through all pages and pages_language_overlay records
+     * and builds the rootline for each page.
+     *
+     * The Rootline Utility does the rest by storing this data to the cache_rootline cache
+     * if it has not happened yet.
+     *
+     * @return array the page Ids with errors
+     */
+    public function warmupRootline(SymfonyStyle $io): array
+    {
+        $erroredPageIds = [];
+        $pageRepository = $this->initializePageRepository();
+
+        // fetch all pages which are not deleted and in live workspace
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('pages');
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $statement = $queryBuilder->select('uid')->from('pages')->execute();
+        while ($pageRecord = $statement->fetch()) {
+            try {
+                $this->buildRootLineForPage(
+                    (int)$pageRecord['uid'],
+                    0,
+                    $pageRepository
+                );
+            } catch (\RuntimeException $e) {
+                $erroredPageIds[] = 'Page ID: ' . $pageRecord['uid'];
+            }
+        }
+
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('pages_language_overlay');
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $statement = $queryBuilder->select('pid', 'sys_language_uid')->from('pages_language_overlay')->execute();
+        while ($pageTranslationRecord = $statement->fetch()) {
+            try {
+                $this->buildRootLineForPage(
+                    (int)$pageTranslationRecord['pid'],
+                    (int)$pageTranslationRecord['sys_language_uid'],
+                    $pageRepository
+                );
+            } catch (\RuntimeException $e) {
+                $erroredPageIds[] = 'Page ID: ' . $pageTranslationRecord['pid'] . ' (Language: ' . $pageTranslationRecord['sys_language_uid'] . ')';
+            }
+        }
+
+        return $erroredPageIds;
+    }
+
+    /**
+     * Calls the Rootline Utility and build the rootline for a specific page in a specific language
+     *
+     * @param int $pageUid
+     * @param int $languageUid
+     * @param PageRepository $pageRepository
+     */
+    protected function buildRootLineForPage(int $pageUid, int $languageUid, PageRepository $pageRepository)
+    {
+        $pageRepository->sys_language_uid = $languageUid;
+        GeneralUtility::makeInstance(RootlineUtility::class, $pageUid, '', $pageRepository)->get();
+    }
+
+    /**
+     * Sets up the PageRepository object with default language and no workspace functionality
+     *
+     * @return PageRepository
+     */
+    protected function initializePageRepository(): PageRepository
+    {
+        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
+        $pageRepository->versioningPreview = false;
+        $pageRepository->sys_language_uid = 0;
+        $pageRepository->versioningWorkspaceId = 0;
+        $pageRepository->init(false);
+
+        // Due to some ugly code in TYPO3 Core, we must fake a TSFE object
+        $GLOBALS['TSFE'] = new \stdClass();
+        $GLOBALS['TSFE']->sys_page = $pageRepository;
+        $GLOBALS['TSFE']->gr_list = '0,-1';
+        return $pageRepository;
+    }
+}

--- a/Classes/Service/RootlineV8Service.php
+++ b/Classes/Service/RootlineV8Service.php
@@ -29,12 +29,9 @@ class RootlineV8Service
      *
      * The Rootline Utility does the rest by storing this data to the cache_rootline cache
      * if it has not happened yet.
-     *
-     * @return array the page Ids with errors
      */
-    public function warmupRootline(SymfonyStyle $io): array
+    public function warmupRootline(SymfonyStyle $io)
     {
-        $erroredPageIds = [];
         $pageRepository = $this->initializePageRepository();
 
         // fetch all pages which are not deleted and in live workspace
@@ -52,7 +49,7 @@ class RootlineV8Service
                     $pageRepository
                 );
             } catch (\RuntimeException $e) {
-                $erroredPageIds[] = 'Page ID: ' . $pageRecord['uid'];
+                $io->error('Rootline Cache for Page ID ' . $pageRecord['uid'] . ' could not be warmed up');
             }
         }
 
@@ -70,11 +67,9 @@ class RootlineV8Service
                     $pageRepository
                 );
             } catch (\RuntimeException $e) {
-                $erroredPageIds[] = 'Page ID: ' . $pageTranslationRecord['pid'] . ' (Language: ' . $pageTranslationRecord['sys_language_uid'] . ')';
+                $io->error('Rootline Cache for Page ID ' . $pageRecord['uid'] . '  (Language: ' . $pageTranslationRecord['sys_language_uid'] . ') could not be warmed up');
             }
         }
-
-        return $erroredPageIds;
     }
 
     /**

--- a/Classes/Service/RootlineWarmupService.php
+++ b/Classes/Service/RootlineWarmupService.php
@@ -23,9 +23,8 @@ use TYPO3\CMS\Core\Utility\RootlineUtility;
 
 class RootlineWarmupService
 {
-    public function warmUp(SymfonyStyle $io): array
+    public function warmUp(SymfonyStyle $io)
     {
-        $erroredPageIds = [];
         // fetch all pages which are not deleted and in live workspace
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('pages');
@@ -38,10 +37,9 @@ class RootlineWarmupService
             try {
                 $this->buildRootLineForPage($pageRecord);
             } catch (\RuntimeException $e) {
-                $erroredPageIds[] = 'Page ID: ' . $pageRecord['uid'];
+                $io->error('Rootline Cache for Page ID ' . $pageRecord['uid'] . ' could not be warmed up');
             }
         }
-        return $erroredPageIds;
     }
 
     protected function buildRootLineForPage(array $pageRecord)

--- a/Classes/Service/RootlineWarmupService.php
+++ b/Classes/Service/RootlineWarmupService.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace B13\Warmup\Service;
+
+/*
+ * This file is part of TYPO3 CMS-based extension "warmup" by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Context\LanguageAspect;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\RootlineUtility;
+
+class RootlineWarmupService
+{
+    public function warmUp(SymfonyStyle $io): array
+    {
+        $erroredPageIds = [];
+        // fetch all pages which are not deleted and in live workspace
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable('pages');
+        $queryBuilder->getRestrictions()
+            ->removeAll()
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class))
+            ->add(GeneralUtility::makeInstance(DeletedRestriction::class));
+        $statement = $queryBuilder->select('*')->from('pages')->execute();
+        while ($pageRecord = $statement->fetch()) {
+            try {
+                $this->buildRootLineForPage($pageRecord);
+            } catch (\RuntimeException $e) {
+                $erroredPageIds[] = 'Page ID: ' . $pageRecord['uid'];
+            }
+        }
+        return $erroredPageIds;
+    }
+
+    protected function buildRootLineForPage(array $pageRecord)
+    {
+        $context = clone GeneralUtility::makeInstance(Context::class);
+        if ($pageRecord['sys_language_uid']) {
+            $context->setAspect('language', new LanguageAspect($pageRecord['sys_language_uid']));
+        }
+        GeneralUtility::makeInstance(RootlineUtility::class, $pageRecord['uid'], '', $context);
+
+    }
+}

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -1,6 +1,6 @@
 <?php
 return [
     'cache:warmup' => [
-        'class' => \CMSExperts\Warmup\Command\WarmupCommand::class
+        'class' => \B13\Warmup\Command\WarmupCommand::class
     ],
 ];

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ then flush caches.
 The current state is intended for TYPO3 v8 LTS, and handles
 the Rootline Cache.
 
+For TYPO3 v9 LTS, pages can be called as well.
 
 ## Rootline Cache
 One of the main issues here is a large installation with lots of
@@ -36,14 +37,13 @@ already in the cache, the command runs smoothly.
 Install the extension by extracting the contents of this folder into
 typo3conf/ext/warmup and install the extension via the Extension Manager.
 
-Alternatively, you can use composer via `composer req cmsexperts/warmup`.
+Alternatively, you can use composer via `composer req b13/warmup`.
 
 
 ## Notes
 
 Note that this extension does not take workspaces or mount points
 into account currently! Contributions are welcome.
-
 
 ## Credits
 

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
-  "name": "cmsexperts/warmup",
+  "name": "b13/warmup",
   "description": "This extension adds a CLI script to warmup the caches.",
   "type": "typo3-cms-extension",
   "keywords": ["TYPO3 CMS", "CLI", "Cache"],
   "license": "GPL-2.0-or-later",
   "require": {
-    "typo3/cms-core": ">=8.7.0,<9.0"
+    "typo3/cms-core": ">=8.7.0,<10.0"
   },
   "autoload": {
     "psr-4": {
-      "CMSExperts\\Warmup\\": "Classes/"
+      "B13\\Warmup\\": "Classes/"
     }
   }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,13 +14,13 @@ $EM_CONF[$_EXTKEY] = array(
 	'title' => 'Cache Warmup',
 	'description' => 'Allows to warmup caches via the command line interface',
 	'category' => 'be',
-	'author' => 'b:dreizehn GmbH',
-	'author_email' => 'typo3@b13.de',
+	'author' => 'b13 GmbH',
+	'author_email' => 'typo3@b13.com',
 	'state' => 'stable',
-	'version' => '1.1.3',
+	'version' => '1.2.0',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '8.7.0-8.7.99',
+			'typo3' => '8.7.0-9.5.99',
 		),
 		'conflicts' => array(
 		),

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,12 +1,9 @@
 <?php
 
-use B13\Warmup\Authentication\FrontendUserGroupInjector;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-
-ExtensionManagementUtility::addService(
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addService(
     'warmup',
     'auth',
-    FrontendUserGroupInjector::class,
+    \B13\Warmup\Authentication\FrontendUserGroupInjector::class,
     [
         'title' => 'Add Frontend Groups based on CLI Request Builder',
         'description' => 'Adds frontend usergroups by verifying data from the Frontend Request Builder.',
@@ -14,6 +11,6 @@ ExtensionManagementUtility::addService(
         'available' => false,
         'priority' => 90,
         'quality' => 90,
-        'className' => FrontendUserGroupInjector::class,
+        'className' => \B13\Warmup\Authentication\FrontendUserGroupInjector::class,
     ]
 );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,0 +1,19 @@
+<?php
+
+use B13\Warmup\Authentication\FrontendUserGroupInjector;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+ExtensionManagementUtility::addService(
+    'warmup',
+    'auth',
+    FrontendUserGroupInjector::class,
+    [
+        'title' => 'Add Frontend Groups based on CLI Request Builder',
+        'description' => 'Adds frontend usergroups by verifying data from the Frontend Request Builder.',
+        'subtype' => 'getGroupsFE',
+        'available' => false,
+        'priority' => 90,
+        'quality' => 90,
+        'className' => FrontendUserGroupInjector::class,
+    ]
+);


### PR DESCRIPTION
You must never use a use statement in the files global scope - that would make the cached script concept break and could conflict with other extensions.